### PR TITLE
Use `with` blocks to manage connections, cursors, and transactions

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import json
 from flask import Flask
 import psycopg2
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 import os
 
 app = Flask(__name__)
@@ -13,60 +12,44 @@ def hello_world():
 
 @app.route('/widgets')
 def get_widgets():
-    conn = psycopg2.connect(
+    with psycopg2.connect(
         host="db",
         user="postgres",
         password=password,
         database="example"
-    )
-    cursor = conn.cursor()
+    ) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT * FROM widgets")
+            
+            row_headers=[x[0] for x in cursor.description]
 
-    cursor.execute("SELECT * FROM widgets")
-
-    row_headers=[x[0] for x in cursor.description]
-
-    results = cursor.fetchall()
-    json_data=[]
-    for result in results:
-        json_data.append(dict(zip(row_headers,result)))
-
-    cursor.close()
-    conn.close()
+            results = cursor.fetchall()
+            json_data=[]
+            for result in results:
+                json_data.append(dict(zip(row_headers,result)))
 
     return json.dumps(json_data)
 
 @app.route('/initdb')
 def db_init():
-    conn = psycopg2.connect(
+    with psycopg2.connect(
         host="db",
         user="postgres",
         password=password,
-    )
-    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    ) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("DROP DATABASE IF EXISTS example")
+            cursor.execute("CREATE DATABASE example")
 
-    cursor = conn.cursor()
-
-    cursor.execute("DROP DATABASE IF EXISTS example")
-    cursor.execute("CREATE DATABASE example")
-
-    cursor.close()
-    conn.commit()
-    conn.close()
-
-    conn = psycopg2.connect(
-    host="db",
-    user="postgres",
-    password=password,
-    database="example"
-    )
-    cursor = conn.cursor()
-
-    cursor.execute("DROP TABLE IF EXISTS widgets")
-    cursor.execute("CREATE TABLE widgets (name VARCHAR(255), description VARCHAR(255))")
-
-    cursor.close()
-    conn.commit()
-    conn.close()
+    with psycopg2.connect(
+        host="db",
+        user="postgres",
+        password=password,
+        database="example"
+    ) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("DROP TABLE IF EXISTS widgets")
+            cursor.execute("CREATE TABLE widgets (name VARCHAR(255), description VARCHAR(255))")
 
     return 'init database'
 


### PR DESCRIPTION
From [the docs](https://www.psycopg.org/docs/connection.html):

> Changed in version 2.5: if the connection is used in a `with` statement, `commit()` is automatically called if no exception is raised in the `with` block.

`with` blocks also make the code exception-safe. If an exception is thrown due to a bad query, then we rollback the transaction instead of leaving the database in a state where some queries succeeded and others failed. We also won't leak the connection and cursor, since an exception would prevent the old code from calling `conn.close()`. It also lets us avoid using `ISOLATION_LEVEL_AUTOCOMMIT`, which is not really something I'd want to steer new programmers towards using.